### PR TITLE
be a little smarter about when to redirect stderr

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -21,6 +21,7 @@ if PY2:
 else:
     from collections.abc import Callable, Sequence
 import inspect
+import io
 import logging
 from numbers import Number
 import os
@@ -443,3 +444,24 @@ def _redirect_stderr():
     os.dup2(devnull, stderr_fileno)
     os.close(devnull)
     return orig_stderr
+
+def _has_fileno(stream):
+    """Returns whether the stream object seems to have a working fileno()
+
+    Tells whether _redirect_stderr is likely to work.
+
+    Parameters
+    ----------
+    stream : IO stream object
+
+    Returns
+    -------
+    has_fileno : bool
+        True if stream.fileno() exists and doesn't raise OSError or
+        UnsupportedOperation
+    """
+    try:
+        stream.fileno()
+    except (AttributeError, OSError, io.UnsupportedOperation):
+        return False
+    return True

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -255,13 +255,14 @@ class StanModel:
         build_extension.build_temp = os.path.dirname(pyx_file)
         build_extension.build_lib = lib_dir
 
-        if not verbose and hasattr(sys.stderr, 'fileno'):
+        redirect_stderr = not verbose and pystan.misc._has_fileno(sys.stderr)
+        if redirect_stderr:
             # silence stderr for compilation
             orig_stderr = pystan.misc._redirect_stderr()
 
         build_extension.run()
 
-        if not verbose and hasattr(sys.stderr, 'fileno'):
+        if redirect_stderr:
             # restore stderr
             os.dup2(orig_stderr, sys.stderr.fileno())
 


### PR DESCRIPTION
The fix in 0e34978 doesn't work in the most recent versions of IPython. Fixes #3 in that case.
