### PR TITLE
handle return parameters correctly in optimizing()

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,7 +406,8 @@ class StanModel:
 
         stan_args = pystan.misc._get_valid_stan_args(stan_args)
         ret, sample = fit._call_sampler(stan_args)
-        return OrderedDict([('par', OrderedDict(zip(m_pars, sample['par']))),
+        pars = pystan.misc._par_vector2dict(sample['par'], m_pars, p_dims)
+        return OrderedDict([('par', pars),
                             ('value', sample['value'])])
 
     def sampling(self, data=None, pars=None, chains=4, iter=2000,


### PR DESCRIPTION
`optimizing()` currently doesn't work for multidimensional parameters.

This uses the generic helper to fix it. One mildly unpleasant side-effect is that scalar parameters then become arrays of shape `(1,)`. I'll leave it up to you if there's a nice way to deal with that in `_par_vector2dict`.
