### PR TITLE
Fix-up random seeds: consistency and unit tests

### DIFF
--- a/pystan/api.py
+++ b/pystan/api.py
@@ -199,7 +199,7 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         parameter values; function returning a dict with initial parameter
         values. The function may take an optional argument `chain_id`.
 
-    seed : int, optional
+    seed : int or np.random.RandomState, optional
         The seed, a positive integer for random number generation. Only
         one seed is needed when multiple chains are used, as the other
         chain's seeds are generated from the first chain's to prevent
@@ -303,9 +303,6 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         data = {}
     if warmup is None:
         warmup = int(iter // 2)
-    if seed is None:
-        seed = random.randint(0, MAX_UINT)
-    seed = int(seed)
     if fit is not None:
         m = fit.stanmodel
     else:

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -351,7 +351,7 @@ class StanModel:
             names are the keys and the values are their associated values.
             Stan only accepts certain kinds of values; see Notes.
 
-        seed : int, optional
+        seed : int or np.random.RandomState, optional
             The seed, a positive integer for random number generation. Only
             one seed is needed when multiple chains are used, as the other
             chain's seeds are generated from the first chain's to prevent
@@ -448,9 +448,7 @@ class StanModel:
                 not isinstance(init, string_types):
             raise ValueError("Wrong specification of initial values.")
 
-        if seed is None:
-            seed = random.randint(0, MAX_UINT)
-        seed = int(seed)
+        seed = pystan.misc._check_seed(seed)
 
         stan_args = dict(init=init,
                          seed=seed,
@@ -503,7 +501,7 @@ class StanModel:
         thin : int, 1 by default
             Positive integer specifying the period for saving samples.
 
-        seed : int, optional
+        seed : int or np.random.RandomState, optional
             The seed, a positive integer for random number generation. Only
             one seed is needed when multiple chains are used, as the other
             chain's seeds are generated from the first chain's to prevent
@@ -637,10 +635,6 @@ class StanModel:
             raise ValueError("The number of chains is less than one; sampling"
                              "not done.")
 
-        if seed is None:
-            seed = random.randint(0, MAX_UINT)
-        seed = int(seed)
-
         args_list = pystan.misc._config_argss(chains=chains, iter=iter,
                                               warmup=warmup, thin=thin,
                                               init=init, seed=seed, sample_file=sample_file,
@@ -675,7 +669,8 @@ class StanModel:
         inits_used = pystan.misc._organize_inits([s['inits'] for s in samples],
                                                  m_pars, p_dims)
 
-        perm_lst = [np.random.permutation(n_kept) for _ in range(chains)]
+        random_state = np.random.RandomState(args_list[0]['seed'])
+        perm_lst = [random_state.permutation(n_kept) for _ in range(chains)]
         fnames_oi = fit._get_param_fnames_oi()
         n_flatnames = len(fnames_oi)
         fit.sim = {'samples': samples,

--- a/pystan/tests/test_basic.py
+++ b/pystan/tests/test_basic.py
@@ -97,6 +97,22 @@ class TestBernoulli(unittest.TestCase):
         assert extr.shape == (1000, 4, 2)
         assert 0.1 < np.mean(extr[:, 0, 0]) < 0.4
 
+    def test_bernoulli_random_seed_consistency(self):
+        thetas = []
+        for _ in range(2):
+            fit = self.model.sampling(data=self.bernoulli_data, seed=42)
+            thetas.append(fit.extract('theta', permuted=True)['theta'])
+        np.testing.assert_equal(*thetas)
+
+    def test_bernoulli_random_seed_inconsistency(self):
+        thetas = []
+        for seed in range(2):
+            # seeds will be 0, 1
+            fit = self.model.sampling(data=self.bernoulli_data,
+                                      seed=np.random.RandomState(seed))
+            thetas.append(fit.extract('theta', permuted=True)['theta'])
+        self.assertFalse(np.allclose(*thetas))
+
     def test_bernoulli_summary(self):
         fit = self.fit
         s = fit.summary()

--- a/pystan/tests/test_misc.py
+++ b/pystan/tests/test_misc.py
@@ -1,6 +1,7 @@
 import numpy as np
 
-from pystan.misc import _pars_total_indexes, _par_vector2dict
+from pystan.constants import MAX_UINT
+from pystan.misc import _pars_total_indexes, _par_vector2dict, _check_seed
 
 
 def test_pars_total_indexes():
@@ -26,3 +27,16 @@ def test_par_vector2dict():
     rslt = _par_vector2dict(v, pars, dims)
     rslt['alpha'] = np.array([0,  1, -1, -1, 0,  1]).reshape(dims[0])
     rslt['beta'] = np.array([-1, -2])
+
+
+def is_valid_seed(seed):
+    return isinstance(seed, int) and seed >= 0 and seed <= MAX_UINT
+
+
+def test_check_seed():
+    assert _check_seed('10') == 10
+    assert _check_seed(10) == 10
+    assert _check_seed(10.5) == 10
+    assert is_valid_seed(_check_seed(np.random.RandomState()))
+    assert is_valid_seed(_check_seed(-1))
+    assert is_valid_seed(_check_seed(MAX_UINT + 1))


### PR DESCRIPTION
All random seeds are now checked (and only checked) by `misc._check_seed`, which now also allows for `np.random.RandomState` objects.

Permutations of samples should now be determined by the seed given to model.sampler, not the `np.random` global state.

There are now unit tests for misc._check_seed and to verify that the model output is exactly reproduced, given the same seed.

Note: I haven't actually run these tests yet since it's a bit of a pain to compile pystan, but they are pretty simple so I think there is a decent chance they will just work when Travis CI tries them.
