### PR TITLE
Use hashlib instead of md5, even for python 2

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -9,11 +9,10 @@ from pystan._compat import PY2, string_types, implements_to_string
 from collections import OrderedDict
 if PY2:
     from collections import Callable, Iterable
-    import md5 as hashlib
 else:
     from collections.abc import Callable, Iterable
-    import hashlib
 import datetime
+import hashlib
 import importlib
 import imp
 import io


### PR DESCRIPTION
Pystan already requires python 2.7, which comes with hashlib.
Actually, hashlib comes with all versions of python since 2.5.

I see a deprecation warnings when I import pystan (using
python 2.7) because python tells me md5 is deprecated.
