### PR TITLE
Default to no compiler optimization for extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,14 +99,16 @@ libstan_sources = [
     "pystan/stan/src/stan/agrad/matrix.cpp"
 ]
 
-extra_compile_args = ['-O3', '-ftemplate-depth-256']
+libstan_extra_compile_args = ['-O3', '-ftemplate-depth-256']
 
 libstan = ('stan', {'sources': libstan_sources,
                     'include_dirs': stan_include_dirs,
-                    'extra_compile_args': extra_compile_args,
+                    'extra_compile_args': libstan_extra_compile_args,
                     'macros': stan_macros})
 
 ## extensions
+extensions_extra_compile_args = ['-O0', '-ftemplate-depth-256']
+
 stanc_sources = [
     "pystan/stan/src/stan/gm/grammars/var_decls_grammar_inst.cpp",
     "pystan/stan/src/stan/gm/grammars/expression_grammar_inst.cpp",
@@ -123,13 +125,13 @@ extensions = [Extension("pystan._api",
                         language='c++',
                         define_macros=stan_macros,
                         include_dirs=stan_include_dirs,
-                        extra_compile_args=extra_compile_args),
+                        extra_compile_args=extensions_extra_compile_args),
               Extension("pystan._chains",
                         ["pystan/_chains.pyx"],
                         language='c++',
                         define_macros=stan_macros,
                         include_dirs=stan_include_dirs,
-                        extra_compile_args=extra_compile_args)]
+                        extra_compile_args=extensions_extra_compile_args)]
 
 ## package data
 package_data_pats = ['*.hpp', '*.pxd', '*.pyx', 'tests/data/*.csv']


### PR DESCRIPTION
clang++ miscompiles the stanc parser at high optimization levels (see https://groups.google.com/d/msg/stan-users/HP3YjPrBKO0/VVuJyE3Gs-EJ).

Fortunately, stanc isn't the thing that needs to be fast.

Since libstan is not affected by this issue, this commit splits out
the compiler flags for libstan from those for the extensions (mostly
stanc), and backs the latter down to -O0.

(Note that I haven't actually tested this exact code, since compiling still takes a while...)
