### PR TITLE
Explication for parallelization parameters

### DIFF
--- a/pystan/api.py
+++ b/pystan/api.py
@@ -269,8 +269,9 @@ def stan(file=None, model_name="anon_model", model_code=None, fit=None,
         - `max_treedepth` : int, positive
 
     n_jobs : int, optional
-        Sample in parallel. If -1 all CPUs are used. If 1, no parallel
-        computing code is used at all, which is useful for debugging.
+        Sample multiple chains in parallel. If -1 all CPUs are used. If 1, no parallel
+        computing code is used at all, which is useful for debugging.  Note that if 
+        `n_jobs` > `chains`, only `chains` number of CPUs can be used.
 
     Returns
     -------

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -587,8 +587,9 @@ class StanModel:
             - `max_treedepth` : int, positive
 
         n_jobs : int, optional
-            Sample in parallel. If -1 all CPUs are used. If 1, no parallel
-            computing code is used at all, which is useful for debugging.
+            Sample multiple chains in parallel. If -1 all CPUs are used. If 1, no parallel
+            computing code is used at all, which is useful for debugging.  Note that if 
+            `n_jobs` > `chains`, only `chains` number of CPUs can be used.
 
         Returns
         -------
@@ -669,6 +670,10 @@ class StanModel:
 
         if n_jobs is None:
             n_jobs = -1
+        elif n_jobs > chains:
+            warnings.warn('`n_jobs` > `chains`, but only `chains` number of processes'
+                          'can be launched.  Increase `chains` to take full advantage'
+                          'of the specified number of CPUs.')
 
         assert len(args_list) == chains
         call_sampler_args = izip(itertools.repeat(data), args_list)


### PR DESCRIPTION
Pystan achieves parallelization by launching multiple chains in parallel, but this has not been made explicit in the docstrings.  This point can be confusing for users because sampling status is reported for one chain at a time as they complete, which makes it seem as though the chains are being run in sequence.  

I've tried to make this more clear by updating the doc string for n_jobs and adding a warning if n_jobs > chains (which would prevent the full number of n_jobs from being used).
