### PR TITLE
Clean up multiprocessing.Pool after use in _map_parallel

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -80,7 +80,7 @@ def _map_parallel(function, args, n_jobs):
         pool.close()
         pool.join()
     else:
-        map_result = map(function, args)
+        map_result = list(map(function, args))
     return map_result
 
 


### PR DESCRIPTION
The pool created for multiprocessing in model._map_parallel() was not
being cleaned up after use, which could potentially leave lots of
abandoned Python processes and unclosed files.
