### PR TITLE
Fix getting started to .plot() scipy dependency

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -149,7 +149,7 @@ parameters of interest, or just an array.
 
     print(fit)
 
-If `matplotlib <http://matplotlib.org/>`_ is installed, a visual summary may
+If `matplotlib <http://matplotlib.org/>`_ and `scipy <http://http://www.scipy.org/>`_ are installed, a visual summary may
 also be displayed using the ``plot()`` method.
 
 .. code-block:: python


### PR DESCRIPTION
fit.plot() requires scipy for kde smoothing on plots, added to docs to make clear.
