### PR TITLE
Make model.show() print nice.

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -325,7 +325,7 @@ class StanModel:
         shutil.rmtree(self._temp_dir, ignore_errors=True)
 
     def show(self):
-        return self.model_code
+        print(self)
 
     @property
     def dso(self):


### PR DESCRIPTION
Previously there was no distinction between model.model_code and model.show().  It seems that model.show() should print something human readable, with the line breaks in model_code being printed nicely on the screen.  
