### PR TITLE
Fix compilation error on Windows 64bit

### DIFF
--- a/pystan/model.py
+++ b/pystan/model.py
@@ -321,7 +321,7 @@ class StanModel:
         if extra_compile_args is None:
             extra_compile_args = []
 
-        if platform.platform().startswith('Win'):
+        if platform.system() == 'Windows':
             if build_extension.compiler in (None, 'msvc'):
                 logger.warning("MSVC compiler is not supported")
                 extra_compile_args = [
@@ -343,6 +343,10 @@ class StanModel:
                     "-pthread",
                     "-fexceptions",
                 ] + extra_compile_args
+                if platform.architecture()[0] == "64bit":
+                    # fix undefined variable
+                    # see https://github.com/cython/cython/issues/2670#issuecomment-432212671
+                    extra_compile_args.append("-DMS_WIN64")
         else:
             # linux or macOS
             extra_compile_args = [


### PR DESCRIPTION
#### Summary:

Apparently some environments need MS_WIN64 defined so calculate SIZEOF_VOID_P.

#### Intended Effect:

Fix compilation issue on Windows (latest/last(?) 2.7)

#### How to Verify:

Run tests

#### Side Effects:

None

#### Documentation:
-
#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
Ari Hartikainen
By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
