### PR TITLE
Remove Python 2 from Windows tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,6 @@ environment:
       secure: mjwuqrrrl71BQoPg5t++MKlVApmBBDAr7GmQtI5YawjhdpCJtMi+Tof4P1ENDCLp
 
   matrix:
-    - CONDA: 27
     - CONDA: 36
     - CONDA: 37
 


### PR DESCRIPTION
It is breaking and doesn't even work as other versions (python 3.x)

#### Summary:

Remove Python 2.7 tests from appveyor.

#### Intended Effect:

It has not worked in a long time (ever?) so let's drop the testing. (Official support should drop in 1 month or more)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
