### PR TITLE
Update/stan 2.22.1 math 3.1.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -96,11 +96,12 @@ test_script:
   - "python -c \"import nose; nose.main()\" --nocapture pystan.tests.test_basic \
      pystan.tests.test_basic_array pystan.tests.test_basic_matrix \
      pystan.tests.test_basic_pars pystan.tests.test_ess \
-     pystan.tests.test_extract pystan.tests.test_fixed_param \
-     pystan.tests.test_linear_regression pystan.tests.test_misc \
-     pystan.tests.test_misc_args pystan.tests.test_optimizing_example \
-     pystan.tests.test_stanc pystan.tests.test_unconstrain_pars \
-     pystan.tests.test_utf8 pystan.tests.test_vb"
+     pystan.tests.test_extra_compile_args pystan.tests.test_extract \
+     pystan.tests.test_fixed_param  pystan.tests.test_linear_regression \
+     pystan.tests.test_misc pystan.tests.test_misc_args \
+     pystan.tests.test_optimizing_example pystan.tests.test_stanc \
+     pystan.tests.test_unconstrain_pars pystan.tests.test_utf8 \
+     pystan.tests.test_vb"
   # Move back to the project folder
   - cd ..
   - ECHO "End of testing"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 doc/_build
+pystan/tests/cached_models
 
 __pycache__
 *.a

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ doc/_build
 __pycache__
 *.a
 *.so
+*.dll
+*.pyd
 *.cpp
 *.pyc
 *.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include MANIFEST.in LICENSE README.rst setup.py
 graft doc
 prune doc/_build
 
-global-exclude *.so
 global-exclude *.pyc
 global-exclude .git*
 global-exclude *.png

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ available, PyStan may be installed from source with the following commands
 ::
 
    git clone --recursive https://github.com/stan-dev/pystan.git
+   cd pystan
    python setup.py install
 
 To install latest development version user can also use ``pip``

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,6 @@ available, PyStan may be installed from source with the following commands
 ::
 
    git clone --recursive https://github.com/stan-dev/pystan.git
-   cd pystan
    python setup.py install
 
 To install latest development version user can also use ``pip``
@@ -83,6 +82,8 @@ To install latest development version user can also use ``pip``
 If you encounter an ``ImportError`` after compiling from source, try changing
 out of the source directory before attempting ``import pystan``. On Linux and
 OS X ``cd /tmp`` will work.
+
+``make`` (``mingw32-make`` on Windows) is a requirement for building from source.
 
 Example
 -------
@@ -131,7 +132,7 @@ Example
     # traceplot are available
     fit.plot()
     plt.show()
-    
+
     # updated traceplot can be plotted with
     import arviz as az
     az.plot_trace(fit)
@@ -150,4 +151,4 @@ Example
 
 .. |zenodo| image:: https://zenodo.org/badge/10256919.svg
     :target: https://zenodo.org/badge/latestdoi/10256919
-    :alt: zenodo citation DOI 
+    :alt: zenodo citation DOI

--- a/doc/hmc_euclidian_metric.rst
+++ b/doc/hmc_euclidian_metric.rst
@@ -46,7 +46,7 @@ To make this reproducible, user can manually set seed for each fit.
     data = dict(N=10, y=[0, 1, 0, 1, 0, 1, 0, 1, 1, 1])
     sm = StanModel(model_code=model_code)
     # initial seed can also be chosen by user
-    # MAX_UINT = 2147483647
+    MAX_UINT = 2147483647
     seed = np.random.randint(0, MAX_UINT, size=1)
     fit = sm.sampling(data=data, seed=seed)
 

--- a/doc/threading_support.rst
+++ b/doc/threading_support.rst
@@ -8,14 +8,11 @@ Threading Support with Pystan 2.22+
 
 PyStan (Stan) uses intel TBB library to handle threading for in-chain parallel computing.
 
-Threading on automatically and the number of threads for each chain can be controlled in
-two ways. The first and recommended way is to use `n_threads` argument given to the `.sampling`
- method. The second way is to define and use `STAN_NUM_THREADS` environmental variable.
+Threading is on automatically. The number of threads for each chain can be controlled with
+`STAN_NUM_THREADS` environmental variable.
 
 Due to use of `multiprocessing` to parallelize chains, user needs to be aware of the cpu usage.
 This means that each chain will use `STAN_NUM_THREADS` cpu cores and this can have an affect on performance.
-By default, n_threads is set to `multiprocessing.cpu_count`.
-PyStan3 uses full threading based approach, where the thread counts are not limited to individual chains.
 
 Windows
 =======
@@ -28,6 +25,7 @@ Example
 
 .. code-block:: python
 
+    import os
     import pystan
 
     # Example model
@@ -93,7 +91,8 @@ Example
     # use the default 4 chains == 4 parallel process
     # used cores = min(cpu_cores, 4*STAN_NUM_THREADS)
 
-    fit = stan_model.sampling(data=stan_data, n_jobs=4, n_threads=4)
+    os.environ["STAN_NUM_THREADS"] = "4"
+    fit = stan_model.sampling(data=stan_data, n_jobs=4)
 
     print(fit)
 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -8,6 +8,9 @@
 
 TBD
 ===
+- Update Stan source to v2.22.1 (`release notes <https://github.com/stan-dev/stan/releases/tag/v2.22.1>`_)
+- Intel TBB supported threading. On by default. Supported on all the main OS (Linux, macOS, Windows).
+- Sampling method has a new `n_threads` argument.
 
 v2.19.1.1 (25. Oct 2019)
 ========================

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -10,7 +10,6 @@ TBD
 ===
 - Update Stan source to v2.22.1 (`release notes <https://github.com/stan-dev/stan/releases/tag/v2.22.1>`_)
 - Intel TBB supported threading. On by default. Supported on all the main OS (Linux, macOS, Windows).
-- Sampling method has a new `n_threads` argument.
 
 v2.19.1.1 (25. Oct 2019)
 ========================

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -5,10 +5,9 @@
 # License. See LICENSE for a text of the license.
 #-----------------------------------------------------------------------------
 import logging
-import platform
 
 from pystan.api import stanc, stan
-from pystan.misc import read_rdump, stan_rdump, stansummary, add_libtbb_path
+from pystan.misc import read_rdump, stan_rdump, stansummary
 from pystan.diagnostics import check_hmc_diagnostics
 from pystan.model import StanModel
 from pystan.lookup import lookup
@@ -17,13 +16,6 @@ logger = logging.getLogger('pystan')
 logger.addHandler(logging.NullHandler())
 if len(logger.handlers) == 1:
     logging.basicConfig(level=logging.INFO)
-
-if platform.system() == "Windows":
-    add_libtbb_path()
-
-# clean imports
-del add_libtbb_path
-del platform
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -19,4 +19,4 @@ if len(logger.handlers) == 1:
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html
-__version__ = '2.22.1.0'
+__version__ = '2.22.1.0dev'

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -7,7 +7,7 @@
 import logging
 
 from pystan.api import stanc, stan
-from pystan.misc import read_rdump, stan_rdump, stansummary
+from pystan.misc import read_rdump, stan_rdump, stansummary, add_libtbb_path
 from pystan.diagnostics import check_hmc_diagnostics
 from pystan.model import StanModel
 from pystan.lookup import lookup
@@ -16,6 +16,9 @@ logger = logging.getLogger('pystan')
 logger.addHandler(logging.NullHandler())
 if len(logger.handlers) == 1:
     logging.basicConfig(level=logging.INFO)
+
+add_libtbb_path()
+del add_libtbb_path
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -5,6 +5,7 @@
 # License. See LICENSE for a text of the license.
 #-----------------------------------------------------------------------------
 import logging
+import platform
 
 from pystan.api import stanc, stan
 from pystan.misc import read_rdump, stan_rdump, stansummary, add_libtbb_path
@@ -17,8 +18,12 @@ logger.addHandler(logging.NullHandler())
 if len(logger.handlers) == 1:
     logging.basicConfig(level=logging.INFO)
 
-add_libtbb_path()
+if platform.system() == "Windows":
+    add_libtbb_path()
+
+# clean imports
 del add_libtbb_path
+del platform
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -22,4 +22,4 @@ del add_libtbb_path
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html
-__version__ = '2.22.0.0'
+__version__ = '2.22.1.0'

--- a/pystan/__init__.py
+++ b/pystan/__init__.py
@@ -19,4 +19,4 @@ if len(logger.handlers) == 1:
 
 # following PEP 386
 # See also https://docs.openstack.org/pbr/latest/user/semver.html
-__version__ = '2.19.1.2dev'
+__version__ = '2.22.0.0'

--- a/pystan/_chains.pyx
+++ b/pystan/_chains.pyx
@@ -12,16 +12,16 @@ import pystan.constants
 
 
 # autocovariance is a template function, which Cython doesn't yet support
-cdef extern from "stan/math/prim/mat/fun/autocovariance.hpp" namespace "stan::math":
+cdef extern from "stan/math/prim/fun/autocovariance.hpp" namespace "stan::math":
     void stan_autocovariance "stan::math::autocovariance<double>"(const vector[double]& y, vector[double]& acov)
 
-cdef extern from "stan/math/prim/mat/fun/sum.hpp" namespace "stan::math":
+cdef extern from "stan/math/prim/fun/sum.hpp" namespace "stan::math":
     double stan_sum "stan::math::sum"(vector[double]& x)
 
-cdef extern from "stan/math/prim/mat/fun/mean.hpp" namespace "stan::math":
+cdef extern from "stan/math/prim/fun/mean.hpp" namespace "stan::math":
     double stan_mean "stan::math::mean"(vector[double]& x)
 
-cdef extern from "stan/math/prim/mat/fun/variance.hpp" namespace "stan::math":
+cdef extern from "stan/math/prim/fun/variance.hpp" namespace "stan::math":
     double stan_variance "stan::math::variance"(vector[double]& x)
 
 

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -16,7 +16,7 @@ import sys
 import shutil
 
 from pystan._compat import PY2
-from pystan.model import load_module, build_tbb
+from pystan.model import load_module
 
 logger = logging.getLogger('pystan')
 

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -64,7 +64,7 @@ def create_fake_model(module_name):
         os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "eigen_3.3.3"),
         os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "boost_1.72.0"),
         os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "sundials_4.1.0", "include"),
-        os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "tbb_2019_U8", "include"),
+        os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "tbb", "include"),
         np.get_include(),
     ]
 

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -32,9 +32,7 @@ def create_fake_model(module_name):
     StanModel
         Dummy StanModel object with specific module name.
     """
-    tbb_dir = os.getenv("STAN_TBB")
-    if tbb_dir is None:
-        tbb_dir = os.path.join(os.path.dirname(__file__), '..', 'stan', 'lib', 'stan_math', 'lib','tbb')
+    tbb_dir = os.path.join(os.path.dirname(__file__), '..', 'stan', 'lib', 'stan_math', 'lib','tbb')
     tbb_dir = os.path.abspath(tbb_dir)
 
     # reverse engineer the name
@@ -170,7 +168,7 @@ def get_module_name(path, open_func=None, open_kwargs=None):
     module_name = ""
     with open_func(path, **open_kwargs) as f:
         # scan first few bytes
-        for i in range(500):
+        for i in range(10000):
             byte, = f.read(1)
             if not PY2:
                 byte = chr(byte)

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -36,8 +36,6 @@ def create_fake_model(module_name):
     if tbb_dir is None:
         tbb_dir = os.path.join(os.path.dirname(__file__), '..', 'stan', 'lib', 'stan_math', 'lib','tbb')
         tbb_dir = os.path.abspath(tbb_dir)
-        if not os.path.exists(tbb_dir):
-            build_tbb()
     else:
         tbb_dir = os.path.abspath(tbb_dir)
 

--- a/pystan/experimental/pickling_tools.py
+++ b/pystan/experimental/pickling_tools.py
@@ -35,9 +35,7 @@ def create_fake_model(module_name):
     tbb_dir = os.getenv("STAN_TBB")
     if tbb_dir is None:
         tbb_dir = os.path.join(os.path.dirname(__file__), '..', 'stan', 'lib', 'stan_math', 'lib','tbb')
-        tbb_dir = os.path.abspath(tbb_dir)
-    else:
-        tbb_dir = os.path.abspath(tbb_dir)
+    tbb_dir = os.path.abspath(tbb_dir)
 
     # reverse engineer the name
     model_name, nonce = module_name.replace("stanfit4", "").rsplit("_", 1)

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -463,7 +463,7 @@ def _config_argss(chains, iter, warmup, thin,
         inits_specified = True
     if not inits_specified and isinstance(init, Callable):
         ## test if function takes argument named "chain_id"
-        if "chain_id" in inspect.getargspec(init).args:
+        if "chain_id" in inspect.getfullargspec(init).args:
             inits = [init(chain_id=id) for id in chain_id]
         else:
             inits = [init()] * chains

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -463,7 +463,8 @@ def _config_argss(chains, iter, warmup, thin,
         inits_specified = True
     if not inits_specified and isinstance(init, Callable):
         ## test if function takes argument named "chain_id"
-        if "chain_id" in inspect.getfullargspec(init).args:
+        getfullargspec = inspect.getfullargspec if hasattr(inspect, "getfullargspec") else inspect.getargspec
+        if "chain_id" in getfullargspec(init).args:
             inits = [init(chain_id=id) for id in chain_id]
         else:
             inits = [init()] * chains

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1492,7 +1492,7 @@ def add_libtbb_path():
             )
         )
 
-def build_stan_tbb():
+def build_stan_tbb(use_debug=False):
     """Build tbb."""
     stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib'))
 
@@ -1519,6 +1519,9 @@ def build_stan_tbb():
     tbb_release = os.path.join(stan_math_lib, "tbb_release")
     tbb_dir = os.path.join(stan_math_lib, "tbb")
 
+    if use_debug:
+        tbb_release, tbb_debug = tbb_debug, tbb_release
+
     if not os.path.exists(tbb_dir):
         os.makedirs(tbb_dir)
 
@@ -1527,7 +1530,8 @@ def build_stan_tbb():
 
     for name in os.listdir(tbb_release):
         srcname = os.path.join(tbb_release, name)
-        shutil.move(srcname, tbb_dir)
+        dstname = os.path.join(tbb_dir, name)
+        shutil.move(srcname, dstname)
 
     if os.path.exists(tbb_release):
         shutil.rmtree(tbb_release)

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,62 +1476,11 @@ def get_last_position(fit, warmup=False):
     return positions
 
 def add_libtbb_path():
-    """Add libtbb to PATH on Windows."""
-    if platform.system() == "Windows":
-        libtbb = os.getenv('STAN_TBB')
-        if libtbb is None:
-            libtbb = os.path.abspath(os.path.join(
-                os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
-            ))
+    """Add libtbb to PATH."""
+    libtbb = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
+    ))
 
-        os.environ['PATH'] = ';'.join(
-            list(
-                OrderedDict.fromkeys(
-                    [libtbb] + os.getenv('PATH', '').split(';')
-                )
-            )
-        )
-
-def build_stan_tbb(use_debug=False):
-    """Build tbb."""
-    stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib'))
-
-    make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
-    cmd = [make]
-
-    tbb_root = os.path.join(stan_math_lib, 'tbb_2019_U8').replace("\\", "/")
-    tbb_src = os.path.join(tbb_root, 'src').replace("\\", "/")
-
-    cmd.extend(['-C', tbb_root])
-    cmd.append('tbb_build_dir={}'.format(stan_math_lib))
-    cmd.append('tbb_build_prefix=tbb')
-    cmd.append('tbb_root={}'.format(tbb_root))
-
-    cmd.append('stdver=c++14')
-
-    compiler = os.getenv('TBB_COMPILER', 'gcc')
-    cmd.append('compiler={}'.format(compiler))
-
-    cwd = os.path.abspath(os.path.dirname(__file__))
-    subprocess.check_call(cmd, cwd=cwd)
-
-    tbb_debug = os.path.join(stan_math_lib, "tbb_debug")
-    tbb_release = os.path.join(stan_math_lib, "tbb_release")
-    tbb_dir = os.path.join(stan_math_lib, "tbb")
-
-    if use_debug:
-        tbb_release, tbb_debug = tbb_debug, tbb_release
-
-    if not os.path.exists(tbb_dir):
-        os.makedirs(tbb_dir)
-
-    if os.path.exists(tbb_debug):
-        shutil.rmtree(tbb_debug)
-
-    for name in os.listdir(tbb_release):
-        srcname = os.path.join(tbb_release, name)
-        dstname = os.path.join(tbb_dir, name)
-        shutil.move(srcname, dstname)
-
-    if os.path.exists(tbb_release):
-        shutil.rmtree(tbb_release)
+    os.environ['PATH'] = ';'.join(
+        list(OrderedDict.fromkeys([libtbb] + os.getenv('PATH', '').split(';')))
+    )

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,17 +1476,24 @@ def get_last_position(fit, warmup=False):
 
 def add_libtbb_path():
     """Add libtbb to PATH on Windows."""
-    if platform.system() == 'Windows':
-        # Add tbb to the $PATH on Windows
-        libtbb = os.getenv('STAN_TBB')
-        if libtbb is None:
-            libtbb = os.path.abspath(os.path.join(
-                os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
-            ))
+    libtbb = os.getenv('STAN_TBB')
+    if libtbb is None:
+        libtbb = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
+        ))
+    if platform.system() == "Windows":
         os.environ['PATH'] = ';'.join(
             list(
                 OrderedDict.fromkeys(
                     [libtbb] + os.getenv('PATH', '').split(';')
+                )
+            )
+        )
+    else:
+        os.environ['LD_LIBRARY_PATH'] = ';'.join(
+            list(
+                OrderedDict.fromkeys(
+                    [libtbb] + os.getenv('LD_LIBRARY_PATH', '').split(';')
                 )
             )
         )

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -28,7 +28,6 @@ import itertools
 import logging
 import math
 from numbers import Number
-import platform
 import os
 import random
 import re

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,7 +1476,7 @@ def get_last_position(fit, warmup=False):
 
 def add_libtbb_path():
     """Add libtbb to PATH on Windows."""
-    if platform.system() == 'Windows':
+    if True: #platform.system() == 'Windows':
         # Add tbb to the $PATH on Windows
         libtbb = os.getenv('STAN_TBB')
         if libtbb is None:

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,7 +1476,7 @@ def get_last_position(fit, warmup=False):
 
 def add_libtbb_path():
     """Add libtbb to PATH on Windows."""
-    if True: # platform.system() == 'Windows':
+    if platform.system() == 'Windows':
         # Add tbb to the $PATH on Windows
         libtbb = os.getenv('STAN_TBB')
         if libtbb is None:

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,13 +1476,13 @@ def get_last_position(fit, warmup=False):
 
 def add_libtbb_path():
     """Add libtbb to PATH on Windows."""
-    if platform.system() == 'Windows':
+    if True: # platform.system() == 'Windows':
         # Add tbb to the $PATH on Windows
         libtbb = os.getenv('STAN_TBB')
         if libtbb is None:
-            libtbb = os.path.join(
+            libtbb = os.path.abspath(os.path.join(
                 os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
-            )
+            ))
         os.environ['PATH'] = ';'.join(
             list(
                 OrderedDict.fromkeys(

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1491,3 +1491,43 @@ def add_libtbb_path():
                 )
             )
         )
+
+def build_stan_tbb():
+    """Build tbb."""
+    stan_math_lib = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib')
+
+    make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
+    cmd = [make]
+
+    tbb_root = os.path.join(stan_math_lib, 'tbb_2019_U8').replace("\\", "/")
+    tbb_src = os.path.join(tbb_root, 'src').replace("\\", "/")
+
+    cmd.extend(['-C', tbb_root])
+    cmd.append('tbb_build_dir={}'.format(stan_math_lib))
+    cmd.append('tbb_build_prefix=tbb')
+    cmd.append('tbb_root={}'.format(tbb_root))
+
+    cmd.append('stdver=c++14')
+
+    compiler = os.getenv('TBB_COMPILER', 'gcc')
+    cmd.append('compiler={}'.format(compiler))
+
+    cwd = os.path.dirname(__file__)
+    subprocess.check_call(cmd, cwd=cwd)
+
+    tbb_debug = os.path.join(stan_math_lib, "tbb_debug")
+    tbb_release = os.path.join(stan_math_lib, "tbb_release")
+    tbb_dir = os.path.join(stan_math_lib, "tbb")
+
+    if not os.path.exists(tbb_dir):
+        os.makedirs(tbb_dir)
+
+    if os.path.exists(tbb_debug):
+        shutil.rmtree(tbb_debug)
+
+    for name in os.listdir(tbb_release):
+        srcname = os.path.join(tbb_release, name)
+        shutil.move(srcname, tbb_dir)
+
+    if os.path.exists(tbb_release):
+        shutil.rmtree(tbb_release)

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -28,6 +28,7 @@ import itertools
 import logging
 import math
 from numbers import Number
+import platform
 import os
 import random
 import re
@@ -1472,3 +1473,20 @@ def get_last_position(fit, warmup=False):
         extract_pos = {key : values[draw_location, i] for key, values in extracted.items()}
         positions.append(extract_pos)
     return positions
+
+def add_libtbb_path():
+    """Add libtbb to PATH on Windows."""
+    if platform.system() == 'Windows':
+        # Add tbb to the $PATH on Windows
+        libtbb = os.getenv('STAN_TBB')
+        if libtbb is None:
+            libtbb = os.path.join(
+                os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
+            )
+        os.environ['PATH'] = ';'.join(
+            list(
+                OrderedDict.fromkeys(
+                    [libtbb] + os.getenv('PATH', '').split(';')
+                )
+            )
+        )

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1494,7 +1494,7 @@ def add_libtbb_path():
 
 def build_stan_tbb():
     """Build tbb."""
-    stan_math_lib = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib')
+    stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib'))
 
     make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
     cmd = [make]
@@ -1512,7 +1512,7 @@ def build_stan_tbb():
     compiler = os.getenv('TBB_COMPILER', 'gcc')
     cmd.append('compiler={}'.format(compiler))
 
-    cwd = os.path.dirname(__file__)
+    cwd = os.path.abspath(os.path.dirname(__file__))
     subprocess.check_call(cmd, cwd=cwd)
 
     tbb_debug = os.path.join(stan_math_lib, "tbb_debug")

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -462,8 +462,7 @@ def _config_argss(chains, iter, warmup, thin,
         inits_specified = True
     if not inits_specified and isinstance(init, Callable):
         ## test if function takes argument named "chain_id"
-        getfullargspec = inspect.getfullargspec if hasattr(inspect, "getfullargspec") else inspect.getargspec
-        if "chain_id" in getfullargspec(init).args:
+        if "chain_id" in inspect.getargspec(init).args:
             inits = [init(chain_id=id) for id in chain_id]
         else:
             inits = [init()] * chains

--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -1476,24 +1476,17 @@ def get_last_position(fit, warmup=False):
 
 def add_libtbb_path():
     """Add libtbb to PATH on Windows."""
-    libtbb = os.getenv('STAN_TBB')
-    if libtbb is None:
-        libtbb = os.path.abspath(os.path.join(
-            os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
-        ))
     if platform.system() == "Windows":
+        libtbb = os.getenv('STAN_TBB')
+        if libtbb is None:
+            libtbb = os.path.abspath(os.path.join(
+                os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib', 'tbb'
+            ))
+
         os.environ['PATH'] = ';'.join(
             list(
                 OrderedDict.fromkeys(
                     [libtbb] + os.getenv('PATH', '').split(';')
-                )
-            )
-        )
-    else:
-        os.environ['LD_LIBRARY_PATH'] = ';'.join(
-            list(
-                OrderedDict.fromkeys(
-                    [libtbb] + os.getenv('LD_LIBRARY_PATH', '').split(';')
                 )
             )
         )

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,7 +406,7 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
-                '-L{}'.format(os.path.abspath(tbb_dir)),
+                '--rpath={}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -283,8 +283,9 @@ class StanModel:
             os.path.join(pystan_dir, "stan", "src"),
             os.path.join(pystan_dir, "stan", "lib", "stan_math"),
             os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "eigen_3.3.3"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "boost_1.69.0"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "boost_1.72.0"),
             os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "sundials_4.1.0", "include"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "tbb_2019_U8", "include"),
             np.get_include(),
         ]
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -43,7 +43,7 @@ logger = logging.getLogger('pystan')
 
 def build_tbb():
     make = "make" if platform.system() != "Windows" else "mingw32-make"
-    cmd = [make, "--compiler=gcc"]
+    cmd = [make, "compiler=gcc"]
     cwd = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb_2019_U8')
     subprocess.check_call(cmd, cwd=cwd)
     build_dir = os.path.join(cwd, "build")

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -61,11 +61,8 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
         try:
             import multiprocessing
             import multiprocessing.pool
-            if n_jobs < 1:
-                n_jobs = multiprocessing.cpu_count()
         except ImportError:
             multiprocessing = None
-            n_jobs = 1
         if (platform.system() == 'Windows') and PY2:
             msg = 'Multiprocessing is not supported on Windows with Python 2.X. Setting n_jobs=1'
             logger.warning(msg)
@@ -74,6 +71,9 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
     old_n_threads = os.getenv('STAN_NUM_THREADS')
     if n_threads is not None:
         os.environ['STAN_NUM_THREADS'] = str(int(n_threads))
+    elif not hasattr(os.environ, 'STAN_NUM_THREADS'):
+        if multiprocessing is not None:
+            os.environ['STAN_NUM_THREADS'] = str(multiprocessing.cpu_count())
 
     # 2nd stage: validate that locking is available on the system and
     #            issue a warning if not

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -235,9 +235,7 @@ class StanModel:
         tbb_dir = os.getenv("STAN_TBB")
         if tbb_dir is None:
             tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
-            tbb_dir = os.path.abspath(tbb_dir)
-        else:
-            tbb_dir = os.path.abspath(tbb_dir)
+        tbb_dir = os.path.abspath(tbb_dir)
 
 
         if stanc_ret is None:

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -75,7 +75,9 @@ def build_tbb():
     if os.path.exists(tbb_debug):
         shutil.rmtree(tbb_debug)
 
-    shutil.move(tbb_release, tbb_dir)
+    for name in os.listdir(tbb_release):
+        srcname = os.path.join(tbb_release, name)
+        shutil.move(srcname, tbb_dir)
 
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`
@@ -416,6 +418,7 @@ class StanModel:
                               libraries=["tbb"],
                               library_dirs=[tbb_dir],
                               extra_compile_args=extra_compile_args,
+                              extra_link_args=["-ltbb"]
                               )
 
         cython_include_dirs = ['.', pystan_dir]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -98,7 +98,7 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
     # reset STAN_NUM_THREADS
     if old_n_threads is not None:
         os.environ['STAN_NUM_THREADS'] = old_n_threads
-    else:
+    elif hasattr(os.environ, 'STAN_NUM_THREADS'):
         del os.environ['STAN_NUM_THREADS']
     return map_result
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -19,7 +19,6 @@ import numbers
 import os
 import platform
 import shutil
-import subprocess
 import string
 import sys
 import tempfile
@@ -27,7 +26,6 @@ import time
 
 import distutils
 from distutils.core import Extension
-from glob import glob
 
 import Cython
 from Cython.Build.Inline import _get_build_extension

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,6 +406,7 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
+                '-rpath', os.path.abspath(tbb_dir),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)
@@ -416,8 +417,7 @@ class StanModel:
                               include_dirs=include_dirs,
                               libraries=["tbb"],
                               library_dirs=[tbb_dir],
-                              extra_compile_args=extra_compile_args,
-                              extra_link_args=['-rpath={}'.format(os.path.abspath(tbb_dir))],
+                              extra_compile_args=extra_compile_args
                               )
 
         cython_include_dirs = ['.', pystan_dir]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -363,7 +363,7 @@ class StanModel:
                 '-Wno-uninitialized',
                 '-std=c++1y',
                 '-DSTAN_THREADS',
-                '-D_REENTRANT',
+                '-D_REENTRANT', # stan-math requires _REENTRANT being defined during compilation to make lgamma_r available.
             ] + extra_compile_args
             extra_link_args = ['-Wl,-rpath,{}'.format(os.path.abspath(tbb_dir))]
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -19,6 +19,7 @@ import numbers
 import os
 import platform
 import shutil
+import subprocess
 import string
 import sys
 import tempfile

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -269,6 +269,7 @@ class StanModel:
 
 
         tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
+        tbb_dir = os.path.abspath(tbb_dir)
         if not os.path.exists(tbb_dir):
             build_tbb()
 
@@ -403,6 +404,7 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
+                '-L{}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)
@@ -411,8 +413,8 @@ class StanModel:
                               sources=[pyx_file],
                               define_macros=stan_macros,
                               include_dirs=include_dirs,
-                              libraries=["tbb", "tbbmalloc", "tbbmalloc_proxy"],
-                              library_dirs=[os.path.abspath(tbb_dir)],
+                              libraries=["tbb"],
+                              library_dirs=[tbb_dir],
                               extra_compile_args=extra_compile_args,
                               )
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,7 +406,6 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
-                '-rpath={}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)
@@ -417,7 +416,8 @@ class StanModel:
                               include_dirs=include_dirs,
                               libraries=["tbb"],
                               library_dirs=[tbb_dir],
-                              extra_compile_args=extra_compile_args
+                              extra_compile_args=extra_compile_args,
+                              extra_link_args=['-rpath={}'.format(os.path.abspath(tbb_dir))],
                               )
 
         cython_include_dirs = ['.', pystan_dir]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -396,6 +396,7 @@ class StanModel:
                     '-DSTAN_THREADS',
                     '-D_REENTRANT',
                 ] + extra_compile_args
+            extra_link_args = []
         else:
             # linux or macOS
             extra_compile_args = [
@@ -406,8 +407,8 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
-                '-Wl,-rpath,{}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
+            extra_link_args = ['-Wl,-rpath,{}'.format(os.path.abspath(tbb_dir))]
 
         distutils.log.set_verbosity(verbose)
         extension = Extension(name=self.module_name,
@@ -417,7 +418,8 @@ class StanModel:
                               include_dirs=include_dirs,
                               libraries=["tbb"],
                               library_dirs=[tbb_dir],
-                              extra_compile_args=extra_compile_args
+                              extra_compile_args=extra_compile_args,
+                              extra_link_args=extra_link_args,
                               )
 
         cython_include_dirs = ['.', pystan_dir]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -299,7 +299,7 @@ class StanModel:
             os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "eigen_3.3.3"),
             os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "boost_1.72.0"),
             os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "sundials_4.1.0", "include"),
-            os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "tbb_2019_U8", "include"),
+            os.path.join(pystan_dir, "stan", "lib", "stan_math", "lib", "tbb", "include"),
             np.get_include(),
         ]
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -269,7 +269,6 @@ class StanModel:
 
 
         tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
-        tbb_shared = os.path.join(tbb_dir, "tbb" + ".so" if platform.system() != "Windows" else ".dll")
         if not os.path.exists(tbb_shared):
             build_tbb()
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -96,10 +96,6 @@ def load_module(module_name, module_path):
 def _map_parallel(function, args, n_jobs):
     """multiprocessing.Pool(processors=n_jobs).map with some error checking"""
     # Following the error checking found in joblib
-    if n_jobs < 1:
-        n_jobs = os.cpu_count()
-    os.environ["STAN_NUM_THREADS"] = str(n_jobs)
-    n_jobs=1
     multiprocessing = int(os.environ.get('JOBLIB_MULTIPROCESSING', 1)) or None
     if multiprocessing:
         try:
@@ -111,6 +107,11 @@ def _map_parallel(function, args, n_jobs):
             msg = "Multiprocessing is not supported on Windows with Python 2.X. Setting n_jobs=1"
             logger.warning(msg)
             n_jobs = 1
+    if n_jobs < 1:
+        n_jobs = multiprocessing.cpu_count()
+    os.environ["STAN_NUM_THREADS"] = str(n_jobs)
+    n_jobs=1
+
     # 2nd stage: validate that locking is available on the system and
     #            issue a warning if not
     if multiprocessing:

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -96,7 +96,10 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
     else:
         map_result = list(map(function, args))
     # reset STAN_NUM_THREADS
-    os.environ['STAN_NUM_THREADS'] = old_n_threads
+    if old_n_threads is not None:
+        os.environ['STAN_NUM_THREADS'] = old_n_threads
+    else:
+        del os.environ['STAN_NUM_THREADS']
     return map_result
 
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -367,7 +367,8 @@ class StanModel:
                     '-D_hypot=hypot',
                     '-pthread',
                     '-fexceptions',
-                    '-DSTAN_THREADS'
+                    '-DSTAN_THREADS',
+                    '-D_REENTRANT',
                 ] + extra_compile_args
         else:
             # linux or macOS
@@ -377,7 +378,8 @@ class StanModel:
                 '-Wno-unused-function',
                 '-Wno-uninitialized',
                 '-std=c++1y',
-                '-DSTAN_THREADS'
+                '-DSTAN_THREADS',
+                '-D_REENTRANT',
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -41,44 +41,6 @@ import pystan.diagnostics
 
 logger = logging.getLogger('pystan')
 
-
-def build_tbb():
-    """Build tbb."""
-    stan_math_lib = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib')
-
-    make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
-    cmd = [make]
-
-    tbb_root = os.path.join(stan_math_lib, 'tbb_2019_U8').replace("\\", "/")
-    tbb_src = os.path.join(tbb_root, 'src').replace("\\", "/")
-
-    cmd.extend(['-C', tbb_root])
-    cmd.append('tbb_build_dir={}'.format(stan_math_lib))
-    cmd.append('tbb_build_prefix=tbb')
-    cmd.append('tbb_root={}'.format(tbb_root))
-
-    cmd.append('stdver=c++14')
-
-    compiler = os.getenv('TBB_COMPILER', 'gcc')
-    cmd.append('compiler={}'.format(compiler))
-
-    cwd = os.path.dirname(__file__)
-    subprocess.check_call(cmd, cwd=cwd)
-
-    tbb_debug = os.path.join(stan_math_lib, "tbb_debug")
-    tbb_release = os.path.join(stan_math_lib, "tbb_release")
-    tbb_dir = os.path.join(stan_math_lib, "tbb")
-
-    if not os.path.exists(tbb_dir):
-        os.makedirs(tbb_dir)
-
-    if os.path.exists(tbb_debug):
-        shutil.rmtree(tbb_debug)
-
-    for name in os.listdir(tbb_release):
-        srcname = os.path.join(tbb_release, name)
-        shutil.move(srcname, tbb_dir)
-
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`
     independently of the Python version."""
@@ -276,8 +238,6 @@ class StanModel:
         if tbb_dir is None:
             tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
             tbb_dir = os.path.abspath(tbb_dir)
-            if not os.path.exists(tbb_dir):
-                build_tbb()
         else:
             tbb_dir = os.path.abspath(tbb_dir)
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -53,6 +53,9 @@ def build_tbb():
     if os.path.exists(tbb_dir):
         rmtree(tbb_dir)
     shutil.copytree(build_object_dir, tbb_dir)
+    print(tbb_dir)
+    print(os.listdir(tbb_dir))
+    print(os.environ)
 
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -42,6 +42,9 @@ logger = logging.getLogger('pystan')
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`
     independently of the Python version."""
+    if platform.system() == "Windows":
+        pystan.misc.add_libtbb_path()
+
     if sys.version_info >= (3,0):
         import pyximport
         pyximport.install()
@@ -229,6 +232,7 @@ class StanModel:
     'anon_model'
 
     """
+
     def __init__(self, file=None, charset='utf-8', model_name="anon_model",
                  model_code=None, stanc_ret=None, include_paths=None,
                  boost_lib=None, eigen_lib=None, verbose=False,

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -95,7 +95,7 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
     else:
         map_result = list(map(function, args))
     # reset STAN_NUM_THREADS
-    elif hasattr(os.environ, 'STAN_NUM_THREADS'):
+    if hasattr(os.environ, 'STAN_NUM_THREADS'):
         del os.environ['STAN_NUM_THREADS']
     return map_result
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -71,6 +71,7 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
             logger.warning(msg)
             n_jobs = 1
 
+    old_n_threads = os.getenv('STAN_NUM_THREADS')
     if n_threads is not None:
         os.environ['STAN_NUM_THREADS'] = str(int(n_threads))
 
@@ -94,6 +95,8 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
             pool.join()
     else:
         map_result = list(map(function, args))
+    # reset STAN_NUM_THREADS
+    os.environ['STAN_NUM_THREADS'] = old_n_threads
     return map_result
 
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -101,14 +101,15 @@ def _map_parallel(function, args, n_jobs):
         try:
             import multiprocessing
             import multiprocessing.pool
+            if n_jobs < 1:
+                n_jobs = multiprocessing.cpu_count()
         except ImportError:
             multiprocessing = None
+            n_jobs = 1
         if sys.platform.startswith("win") and PY2:
             msg = "Multiprocessing is not supported on Windows with Python 2.X. Setting n_jobs=1"
             logger.warning(msg)
             n_jobs = 1
-    if n_jobs < 1:
-        n_jobs = multiprocessing.cpu_count()
     os.environ["STAN_NUM_THREADS"] = str(n_jobs)
     n_jobs=1
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -43,7 +43,7 @@ logger = logging.getLogger('pystan')
 
 def build_tbb():
     make = "make" if platform.system() != "Windows" else "mingw32-make"
-    cmd = [make, "--target=gcc"]
+    cmd = [make, "--compiler=gcc"]
     cwd = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb_2019_U8')
     subprocess.check_call(cmd, cwd=cwd)
     build_dir = os.path.join(cwd, "build")

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,7 +406,7 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
-                '-rpath', os.path.abspath(tbb_dir),
+                '-Wl,-rpath,{}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -48,7 +48,7 @@ def build_tbb():
     cwd = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb_2019_U8')
     subprocess.check_call(cmd, cwd=cwd)
     build_dir = os.path.join(cwd, "build")
-    build_object_dir = glob(os.path.join(build_dir, "gcc*_release"))[0]
+    build_object_dir = glob(os.path.join(build_dir, "*gcc*_release"))[0]
     tbb_dir = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib','tbb')
     if os.path.exists(tbb_dir):
         rmtree(tbb_dir)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -269,7 +269,7 @@ class StanModel:
 
 
         tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
-        if not os.path.exists(tbb_shared):
+        if not os.path.exists(tbb_dir):
             build_tbb()
 
 

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -417,8 +417,7 @@ class StanModel:
                               include_dirs=include_dirs,
                               libraries=["tbb"],
                               library_dirs=[tbb_dir],
-                              extra_compile_args=extra_compile_args,
-                              extra_link_args=["-ltbb"]
+                              extra_compile_args=extra_compile_args
                               )
 
         cython_include_dirs = ['.', pystan_dir]

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -27,6 +27,7 @@ import time
 
 import distutils
 from distutils.core import Extension
+from glob import glob
 
 import Cython
 from Cython.Build.Inline import _get_build_extension
@@ -47,10 +48,7 @@ def build_tbb():
     cwd = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb_2019_U8')
     subprocess.check_call(cmd, cwd=cwd)
     build_dir = os.path.join(cwd, "build")
-    if platform.system() == "Windows":
-        build_object_dir = glob(os.path.join(build_dir, "windows*gcc*_release"))[0]
-    else:
-        build_object_dir = glob(os.path.join(build_dir, "*_release"))[0]
+    build_object_dir = glob(os.path.join(build_dir, "gcc*_release"))[0]
     tbb_dir = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib','tbb')
     if os.path.exists(tbb_dir):
         rmtree(tbb_dir)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -406,7 +406,7 @@ class StanModel:
                 '-std=c++1y',
                 '-DSTAN_THREADS',
                 '-D_REENTRANT',
-                '--rpath={}'.format(os.path.abspath(tbb_dir)),
+                '-rpath={}'.format(os.path.abspath(tbb_dir)),
             ] + extra_compile_args
 
         distutils.log.set_verbosity(verbose)

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -68,11 +68,10 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
             logger.warning(msg)
             n_jobs = 1
 
-    old_n_threads = os.getenv('STAN_NUM_THREADS')
     if n_threads is not None:
         os.environ['STAN_NUM_THREADS'] = str(int(n_threads))
-    elif not hasattr(os.environ, 'STAN_NUM_THREADS'):
-        if multiprocessing is not None:
+    else:
+        if multiprocessing:
             os.environ['STAN_NUM_THREADS'] = str(multiprocessing.cpu_count())
 
     # 2nd stage: validate that locking is available on the system and
@@ -96,8 +95,6 @@ def _map_parallel(function, args, n_jobs, n_threads=None):
     else:
         map_result = list(map(function, args))
     # reset STAN_NUM_THREADS
-    if old_n_threads is not None:
-        os.environ['STAN_NUM_THREADS'] = old_n_threads
     elif hasattr(os.environ, 'STAN_NUM_THREADS'):
         del os.environ['STAN_NUM_THREADS']
     return map_result
@@ -238,10 +235,9 @@ class StanModel:
                  obfuscate_model_name=True, extra_compile_args=None,
                  allow_undefined=False, include_dirs=None, includes=None):
 
-        tbb_dir = os.getenv("STAN_TBB")
-        if tbb_dir is None:
-            tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
-        tbb_dir = os.path.abspath(tbb_dir)
+        tbb_dir = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb'
+        ))
 
 
         if stanc_ret is None:

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -75,17 +75,7 @@ def build_tbb():
     if os.path.exists(tbb_debug):
         shutil.rmtree(tbb_debug)
 
-    extension = ".so" if platform.system() != "Windows" else ".dll"
-
-    tbb_shared = "tbb{}".format(extension)
-    tbbmalloc_shared = "tbbmalloc{}".format(extension)
-    tbbmalloc_proxy_shared = "tbbmalloc_proxy{}".format(extension)
-
-    shutil.copy2(os.path.join(tbb_release, tbb_shared), os.path.join(tbb_dir, tbb_shared))
-    shutil.copy2(os.path.join(tbb_release, tbbmalloc_shared), os.path.join(tbb_dir, tbbmalloc_shared))
-    shutil.copy2(os.path.join(tbb_release, tbbmalloc_proxy_shared), os.path.join(tbb_dir, tbbmalloc_proxy_shared))
-
-    shutil.rmtree(tbb_release)
+    shutil.move(tbb_release, tbb_dir)
 
 def load_module(module_name, module_path):
     """Load the module named `module_name` from  `module_path`

--- a/pystan/model.py
+++ b/pystan/model.py
@@ -271,11 +271,14 @@ class StanModel:
                  obfuscate_model_name=True, extra_compile_args=None,
                  allow_undefined=False, include_dirs=None, includes=None):
 
-
-        tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
-        tbb_dir = os.path.abspath(tbb_dir)
-        if not os.path.exists(tbb_dir):
-            build_tbb()
+        tbb_dir = os.getenv("STAN_TBB")
+        if tbb_dir is None:
+            tbb_dir = os.path.join(os.path.dirname(__file__), 'stan', 'lib', 'stan_math', 'lib','tbb')
+            tbb_dir = os.path.abspath(tbb_dir)
+            if not os.path.exists(tbb_dir):
+                build_tbb()
+        else:
+            tbb_dir = os.path.abspath(tbb_dir)
 
 
         if stanc_ret is None:

--- a/pystan/py_var_context.hpp
+++ b/pystan/py_var_context.hpp
@@ -11,7 +11,6 @@
 #include <stan/io/var_context.hpp>
 #include <stan/io/dump.hpp>
 #include <stan/io/ends_with.hpp>
-#include <stan/io/json/json_data.hpp>
 
 /* see stan/io/dump.hpp */
 
@@ -168,7 +167,7 @@ namespace pystan {
        *
        * @param names Vector to store the list of names in.
        */
-      virtual void names_r(std::vector<std::string>& names) const {
+      void names_r(std::vector<std::string>& names) const {
         names.resize(0);
         for (std::map<std::string,
                       std::pair<std::vector<double>,
@@ -184,7 +183,7 @@ namespace pystan {
        *
        * @param names Vector to store the list of names in.
        */
-      virtual void names_i(std::vector<std::string>& names) const {
+      void names_i(std::vector<std::string>& names) const {
         names.resize(0);
         for (std::map<std::string,
                       std::pair<std::vector<int>,
@@ -206,6 +205,40 @@ namespace pystan {
           || (vars_r_.erase(name) > 0);
       }
 
+      /**
+       * Check variable dimensions against variable declaration.
+       *
+       * @param stage stan program processing stage
+       * @param name variable name
+       * @param base_type declared stan variable type
+       * @param dims variable dimensions
+       * @throw std::runtime_error if mismatch between declared
+       *        dimensions and dimensions found in context.
+       */
+      void validate_dims(
+        const std::string& stage, const std::string& name,
+        const std::string& base_type,
+        const std::vector<size_t>& dims_declared) const {
+        bool is_int_type = base_type == "int";
+        if (is_int_type) {
+          if (!contains_i(name)) {
+            std::stringstream msg;
+            msg << (contains_r(name) ? "int variable contained non-int values"
+                                     : "variable does not exist")
+                << "; processing stage=" << stage << "; variable name=" << name
+                << "; base type=" << base_type;
+            throw std::runtime_error(msg.str());
+          }
+        } else {
+          if (!contains_r(name)) {
+            std::stringstream msg;
+            msg << "variable does not exist"
+                << "; processing stage=" << stage << "; variable name=" << name
+                << "; base type=" << base_type;
+            throw std::runtime_error(msg.str());
+          }
+        }
+
     };
 
     std::shared_ptr<stan::io::var_context> get_var_context(const std::string file) {
@@ -215,19 +248,13 @@ namespace pystan {
       msg << "Can't open specified file, \"" << file << "\"" << std::endl;
       throw std::invalid_argument(msg.str());
     }
-    if (stan::io::ends_with(".json", file)) {
-      stan::json::json_data var_context(stream);
-      stream.close();
-      std::shared_ptr<stan::io::var_context> result = std::make_shared<stan::json::json_data>(var_context);
-      return result;
-    }
     stan::io::dump var_context(stream);
     stream.close();
     std::shared_ptr<stan::io::var_context> result = std::make_shared<stan::io::dump>(var_context);
     return result;
     }
 
-  }
+  };
 
 }
 

--- a/pystan/py_var_context.hpp
+++ b/pystan/py_var_context.hpp
@@ -239,6 +239,7 @@ namespace pystan {
           }
         }
 
+      };
     };
 
     std::shared_ptr<stan::io::var_context> get_var_context(const std::string file) {
@@ -254,7 +255,7 @@ namespace pystan {
     return result;
     }
 
-  };
+  }
 
 }
 

--- a/pystan/py_var_context.hpp
+++ b/pystan/py_var_context.hpp
@@ -167,7 +167,7 @@ namespace pystan {
        *
        * @param names Vector to store the list of names in.
        */
-      void names_r(std::vector<std::string>& names) const {
+      virtual void names_r(std::vector<std::string>& names) const {
         names.resize(0);
         for (std::map<std::string,
                       std::pair<std::vector<double>,
@@ -183,7 +183,7 @@ namespace pystan {
        *
        * @param names Vector to store the list of names in.
        */
-      void names_i(std::vector<std::string>& names) const {
+      virtual void names_i(std::vector<std::string>& names) const {
         names.resize(0);
         for (std::map<std::string,
                       std::pair<std::vector<int>,

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -38,7 +38,6 @@ np.import_array()
 # python imports
 from collections import OrderedDict
 import logging
-import platform
 import warnings
 
 import numpy as np
@@ -50,9 +49,6 @@ from pystan.constants import (sampling_algo_t, optim_algo_t, variational_algo_t,
                               sampling_metric_t, stan_args_method_t)
 
 logger = logging.getLogger('pystan')
-
-if platform.system() == "Windows":
-    pystan.misc.add_libtbb_path()
 
 cdef extern from "boost/random/additive_combine.hpp" namespace "boost::random":
     cdef cppclass additive_combine_engine[T, U]:

--- a/pystan/stanfit4model.pyx
+++ b/pystan/stanfit4model.pyx
@@ -38,6 +38,7 @@ np.import_array()
 # python imports
 from collections import OrderedDict
 import logging
+import platform
 import warnings
 
 import numpy as np
@@ -49,6 +50,9 @@ from pystan.constants import (sampling_algo_t, optim_algo_t, variational_algo_t,
                               sampling_metric_t, stan_args_method_t)
 
 logger = logging.getLogger('pystan')
+
+if platform.system() == "Windows":
+    pystan.misc.add_libtbb_path()
 
 cdef extern from "boost/random/additive_combine.hpp" namespace "boost::random":
     cdef cppclass additive_combine_engine[T, U]:

--- a/pystan/tests/test_extra_compile_args.py
+++ b/pystan/tests/test_extra_compile_args.py
@@ -16,12 +16,6 @@ class TestExtraCompileArgs(unittest.TestCase):
             '-Wno-unused-function',
             '-Wno-uninitialized',
         ]
-        if sys.platform.startswith("win"):
-            extra_compile_args.extend([
-                "-D_hypot=hypot",
-                "-pthread",
-                "-fexceptions"
-            ])
         model_code = 'parameters {real y;} model {y ~ normal(0,1);}'
         model = pystan.StanModel(model_code=model_code, model_name="normal1",
                                  extra_compile_args=extra_compile_args)
@@ -41,13 +35,8 @@ class TestExtraCompileArgs(unittest.TestCase):
                              extra_compile_args=extra_compile_args)
 
     def test_threading_support(self):
-        # Dont test with Windows with MinGW-w64 (GCC)
-        if sys.platform.startswith("win"):
-            return
         # Set up environmental variable
         os.environ['STAN_NUM_THREADS'] = "2"
-        # Enable threading
-        extra_compile_args = ['-pthread', '-DSTAN_THREADS']
         stan_code = """
         functions {
           vector bl_glm(vector mu_sigma, vector beta,
@@ -99,10 +88,7 @@ class TestExtraCompileArgs(unittest.TestCase):
                  0.517, 1.092, -0.485, -2.157],
             y = [1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1]
         )
-        stan_model = pystan.StanModel(
-            model_code=stan_code,
-            extra_compile_args=extra_compile_args
-        )
+        stan_model = pystan.StanModel(model_code=stan_code)
         for i in range(10):
             try:
                 fit = stan_model.sampling(data=stan_data, chains=2, iter=200, n_jobs=1)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import ast
 import codecs
 import os
 import platform
+import shutil
 import subprocess
 import sys
 
@@ -116,6 +117,8 @@ def build_tbb():
 
     if os.path.exists(tbb_release):
         shutil.rmtree(tbb_release)
+    print(os.listdir(stan_math_lib))
+    print(os.listdir(tbb_dir))
 
 
 ###############################################################################

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def build_tbb():
     """Build tbb."""
     stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib'))
 
-    make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
+    make = 'make' if platform.system() != 'Windows' else 'mingw32-make'
     cmd = [make]
 
     tbb_root = os.path.join(stan_math_lib, 'tbb_2019_U8').replace("\\", "/")
@@ -92,8 +92,7 @@ def build_tbb():
 
     cmd.append('stdver=c++14')
 
-    compiler = os.getenv('TBB_COMPILER', 'gcc')
-    cmd.append('compiler={}'.format(compiler))
+    cmd.append('compiler=gcc')
 
     cwd = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -79,8 +79,7 @@ def find_version(*parts):
 def build_tbb():
     """Build tbb."""
     stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib'))
-    print(stan_math_lib)
-    print(os.listdir(stan_math_lib))
+
     make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
     cmd = [make]
 
@@ -97,8 +96,7 @@ def build_tbb():
     cmd.append('compiler={}'.format(compiler))
 
     cwd = os.path.abspath(os.path.dirname(__file__))
-    print(cmd)
-    print(cwd)
+
     subprocess.check_call(cmd, cwd=cwd)
 
     tbb_debug = os.path.join(stan_math_lib, "tbb_debug")
@@ -117,8 +115,6 @@ def build_tbb():
 
     if os.path.exists(tbb_release):
         shutil.rmtree(tbb_release)
-    print(os.listdir(stan_math_lib))
-    print(os.listdir(tbb_dir))
 
 
 ###############################################################################

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,8 @@ def find_version(*parts):
 def build_tbb():
     """Build tbb."""
     stan_math_lib = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib')
-
+    print(stan_math_lib)
+    print(os.listdir(stan_math_lib)
     make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
     cmd = [make]
 
@@ -96,6 +97,8 @@ def build_tbb():
     cmd.append('compiler={}'.format(compiler))
 
     cwd = os.path.dirname(__file__)
+    print(cmd)
+    print(cwd)
     subprocess.check_call(cmd, cwd=cwd)
 
     tbb_debug = os.path.join(stan_math_lib, "tbb_debug")
@@ -225,6 +228,7 @@ package_data_pats = ['*.hpp', '*.pxd', '*.pyx', 'tests/data/*.csv',
 
 # Build tbb before setup if needed
 tbb_path = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib', 'tbb')
+print(tbb_path)
 if not os.path.exists(tbb_path):
     build_tbb()
 

--- a/setup.py
+++ b/setup.py
@@ -77,14 +77,13 @@ def find_version(*parts):
 
 def build_tbb():
     """Build tbb."""
-    stan_math_lib = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib')
+    stan_math_lib = os.path.abspath(os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib'))
     print(stan_math_lib)
     print(os.listdir(stan_math_lib))
     make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
     cmd = [make]
 
     tbb_root = os.path.join(stan_math_lib, 'tbb_2019_U8').replace("\\", "/")
-    tbb_src = os.path.join(tbb_root, 'src').replace("\\", "/")
 
     cmd.extend(['-C', tbb_root])
     cmd.append('tbb_build_dir={}'.format(stan_math_lib))
@@ -96,7 +95,7 @@ def build_tbb():
     compiler = os.getenv('TBB_COMPILER', 'gcc')
     cmd.append('compiler={}'.format(compiler))
 
-    cwd = os.path.dirname(__file__)
+    cwd = os.path.abspath(os.path.dirname(__file__))
     print(cmd)
     print(cwd)
     subprocess.check_call(cmd, cwd=cwd)

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ stan_include_dirs = ['pystan/stan/src',
                      'pystan/stan/lib/stan_math/lib/eigen_3.3.3',
                      'pystan/stan/lib/stan_math/lib/boost_1.72.0',
                      'pystan/stan/lib/stan_math/lib/sundials_4.1.0/include',
-                     'pystan/stan/lib/stan_math/lib/tbb_2019_U8/include']
+                     'pystan/stan/lib/stan_math/lib/tbb/include']
 stan_macros = [
     ('BOOST_DISABLE_ASSERTS', None),
     ('BOOST_NO_DECLTYPE', None),

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ def build_tbb():
     """Build tbb."""
     stan_math_lib = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib')
     print(stan_math_lib)
-    print(os.listdir(stan_math_lib)
+    print(os.listdir(stan_math_lib))
     make = os.getenv('MAKE', 'make' if platform.system() != 'Windows' else 'mingw32-make')
     cmd = [make]
 

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,9 @@ def build_tbb():
     if os.path.exists(tbb_debug):
         shutil.rmtree(tbb_debug)
 
+    shutil.move(os.path.join(tbb_root, 'include'), tbb_dir)
+    shutil.rmtree(tbb_root)
+
     for name in os.listdir(tbb_release):
         srcname = os.path.join(tbb_release, name)
         dstname = os.path.join(tbb_dir, name)

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,8 @@ def build_tbb():
 
     for name in os.listdir(tbb_release):
         srcname = os.path.join(tbb_release, name)
-        shutil.move(srcname, tbb_dir)
+        dstname = os.path.join(tbb_dir, name)
+        shutil.move(srcname, dstname)
 
     if os.path.exists(tbb_release):
         shutil.rmtree(tbb_release)
@@ -225,9 +226,9 @@ package_data_pats = ['*.hpp', '*.pxd', '*.pyx', 'tests/data/*.csv',
                      'tests/data/*.stan', 'lookuptable/*.txt']
 
 # Build tbb before setup if needed
-tbb_path = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib', 'tbb')
-print(tbb_path)
-if not os.path.exists(tbb_path):
+tbb_dir = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib', 'tbb')
+tbb_dir = os.path.abspath(tbb_dir)
+if not os.path.exists(tbb_dir):
     build_tbb()
 
 # get every file under pystan/stan/src and pystan/stan/lib

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,10 @@ def find_version(*parts):
     return finder.version
 
 
+def build_tbb():
+    pass
+
+
 ###############################################################################
 # Optional setuptools features
 # We need to import setuptools early, if we want setuptools features,
@@ -102,7 +106,8 @@ stan_include_dirs = ['pystan/stan/src',
                      'pystan/stan/lib/stan_math/',
                      'pystan/stan/lib/stan_math/lib/eigen_3.3.3',
                      'pystan/stan/lib/stan_math/lib/boost_1.69.0',
-                     'pystan/stan/lib/stan_math/lib/sundials_4.1.0/include']
+                     'pystan/stan/lib/stan_math/lib/sundials_4.1.0/include',
+                     'pystan/stan/lib/stan_math/lib/tbb']
 stan_macros = [
     ('BOOST_DISABLE_ASSERTS', None),
     ('BOOST_NO_DECLTYPE', None),
@@ -118,7 +123,7 @@ extra_compile_args = [
     '-std=c++1y',
 ]
 
-if platform.platform().startswith('Win'):
+if platform.system() == 'Windows':
     from Cython.Build.Inline import _get_build_extension
     if _get_build_extension().compiler in (None, 'msvc'):
         print("Warning: MSVC is not supported")
@@ -214,6 +219,7 @@ def setup_package():
                     long_description_content_type='text/x-rst',
                     classifiers=CLASSIFIERS,
                     **extra_setuptools_args)
+    build_tbb()
     if len(sys.argv) >= 2 and ('--help' in sys.argv[1:] or sys.argv[1]
                                in ('--help-commands', 'egg_info', '--version', 'clean')):
         # For these actions, neither Numpy nor Cython is required.

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ from distutils.extension import Extension
 stan_include_dirs = ['pystan/stan/src',
                      'pystan/stan/lib/stan_math/',
                      'pystan/stan/lib/stan_math/lib/eigen_3.3.3',
-                     'pystan/stan/lib/stan_math/lib/boost_1.69.0',
+                     'pystan/stan/lib/stan_math/lib/boost_1.72.0',
                      'pystan/stan/lib/stan_math/lib/sundials_4.1.0/include',
                      'pystan/stan/lib/stan_math/lib/tbb_2019_U8/include']
 stan_macros = [

--- a/setup.py
+++ b/setup.py
@@ -75,22 +75,6 @@ def find_version(*parts):
     return finder.version
 
 
-def build_tbb():
-    make = "make" if platform.system() != "Windows" else "mingw32-make"
-    cmd = [make, "--target=gcc"]
-    cwd = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib','tbb_2019_U8')
-    subprocess.check_call(cmd, cwd=cwd)
-    build_dir = os.path.join(cwd, "build")
-    if platform.system() == "Windows":
-        build_object_dir = glob(os.path.join(build_dir, "windows*gcc*_release"))[0]
-    else:
-        build_object_dir = glob(os.path.join(build_dir, "*_release"))[0]
-    tbb_dir = os.path.join(os.path.dirname(__file__), 'pystan', 'stan', 'lib', 'stan_math', 'lib','tbb')
-    if os.path.exists(tbb_dir):
-        rmtree(tbb_dir)
-    shutil.copytree(build_object_dir, tbb_dir)
-
-
 ###############################################################################
 # Optional setuptools features
 # We need to import setuptools early, if we want setuptools features,
@@ -261,7 +245,6 @@ def setup_package():
         metadata['cmdclass'] = {'install': install.install}
     try:
         dist.run_commands()
-        build_tbb()
     except KeyboardInterrupt:
         raise SystemExit("Interrupted")
     except (IOError, os.error) as exc:


### PR DESCRIPTION
#### Summary:

Updates `stan` source to 2.22.1 and `stan_math` to 3.0.0

Fixes:
- Update var_context
- build and link to TBB (`stan-math/lib/tbb`)
    - TBB is build at setup step and distributed with `.whl`, it is not "installed".
    - Use `rpath` for TBB linking on Linux/macOS
    - Add `TBB` to PATH in load_module function on Windows
- `make` as a build requirement (`mingw32-make` on Windows)
- update stan paths (`_chains.pyx`)
- `-D_REENTRANT` added as a `CXXFLAG`
- Stan threading is now always on, still uses multiprocessing for `n_jobs`. (STAN_NUM_THREADS for multiple threads)
- Threading works on Windows with mingw-w64 compiler. Added testing for threading on Windows.

#### Intended Effect:

Update Stan.

#### How to Verify:

Run tests.

#### Side Effects:

Extra handling for TBB.

#### Documentation:

Threading docs updated.

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
