### PR TITLE
Add minimal comment inv_metric dict keys

### DIFF
--- a/doc/hmc_euclidian_metric.rst
+++ b/doc/hmc_euclidian_metric.rst
@@ -53,6 +53,7 @@ To make this reproducible, user can manually set seed for each fit.
     # reuse tuned parameters
     stepsize = fit.get_stepsize()
     # by default .get_inv_metric returns a list
+    # dict should always go from 0 -> chains-1
     inv_metric = fit.get_inv_metric(as_dict=True)
     init = fit.get_last_position()
 


### PR DESCRIPTION
#### Summary:

inv_metric dict should always start from `0` and go to `chains-1`

#### Intended Effect:

chain_id is not used

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

Ari Hartikainen

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
