### PR TITLE
Replace deprecated `getargspec`

### DIFF
--- a/pystan/misc.py
+++ b/pystan/misc.py
@@ -462,7 +462,7 @@ def _config_argss(chains, iter, warmup, thin,
         inits_specified = True
     if not inits_specified and isinstance(init, Callable):
         ## test if function takes argument named "chain_id"
-        if "chain_id" in inspect.getargspec(init).args:
+        if "chain_id" in inspect.getfullargspec(init).args:
             inits = [init(chain_id=id) for id in chain_id]
         else:
             inits = [init()] * chains


### PR DESCRIPTION
#### Summary:

`inspect.getargspec` throws an error if the callable passed as an argument contains annotations. `inspect.getfullargspec` serves the same purpose and works fine with annotated functions.

#### Intended Effect:

#### How to Verify:

#### Side Effects:

#### Documentation:

#### Reviewer Suggestions: 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
