### PR TITLE
Update index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -64,6 +64,7 @@ Related projects
 - hBayesDM: `hierarchical Bayesian modeling of Decision-Making tasks <https://hbayesdm.readthedocs.io>`_ by @CCS-Lab
 - Jupyter tool: `StanMagic <https://github.com/Arvinds-ds/stanmagic>`_ by @Arvinds-ds
 - Jupyter tool: `JupyterStan <https://github.com/janfreyberg/jupyterstan>`_ by @janfreyberg
+- Orbit: `Object-oRiented BayesIan Timeseries models <https://github.com/uber/orbit>`_ by @uber
 - Prophet: `Timeseries forecasting <https://facebook.github.io/prophet/>`_ by @facebook
 - Scikit-learn integration: `pystan-sklearn <https://github.com/rgerkin/pystan-sklearn>`_ by @rgerkin.
 


### PR DESCRIPTION
Summary:
Proposed to include Orbit in the related projects section

Intended Effect:
N/A

How to Verify:
N/A

Side Effects:
N/A

Documentation:
Just a change in the `index.rst` to add link of `Orbit` by uber

Reviewer Suggestions:
Copyright and Licensing
`Orbit` is under GPL3

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:

Code: GPLv3 (http://opensource.org/licenses/GPL-3.0)
Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)